### PR TITLE
Remove harcoded version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
     "magento/module-csp": "*"
   },
   "type": "magento2-module",
-  "version": "1.0.1",
   "autoload": {
     "files": [
       "registration.php"


### PR DESCRIPTION
Remove harcoded version from composer.json to ensure git versioning is used properly by repo managers like packagist or satis.